### PR TITLE
Remove .treatAllWarnings(as: .error) from Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -77,7 +77,6 @@ func swiftSettings(_ settings: PackageDescription.SwiftSetting...) -> [PackageDe
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
-    .treatAllWarnings(as: .error),
   ] + settings
 }
 


### PR DESCRIPTION
The introduction of `.treatAllWarnings(as: .error)` seems to have caused some problems with Xcode pulling the package in as a dependency. Xcode suppresses warnings when building SPM packages. This conflicts with the `-warnings-as-errors` flag, resulting in a conflicting set of build flags in the project:

```
error: Conflicting options '-warnings-as-errors' and '-suppress-warnings' (in target 'JPEG' from project 'swift-tui')
```

There's ways to build the package with `-warnings-as-errors` outside of the Package.swift definition; this allows consuming Xcode projects to continue to use the package while the CI tooling continues to treat all warnings as errors.