### PR TITLE
Fix key bubbling from synthetic focus targets

### DIFF
--- a/Sources/SwiftTUIGraph/Resolve/NodeHandlers.swift
+++ b/Sources/SwiftTUIGraph/Resolve/NodeHandlers.swift
@@ -120,7 +120,8 @@ package struct ContributedHandlerNodeRecord<Handler>: RuntimeNodeRecord {
 
 package struct KeyHandlerNodeRecord: RuntimeNodeRecord {
   package var owners: [Identity: RuntimeRegistrationOwnerKey] = [:]
-  package var keyPress = ContributedHandlerNodeRecord<LocalKeyHandlerRegistry.KeyPressHandler>()
+  package var keyPress =
+    ContributedHandlerNodeRecord<LocalKeyHandlerRegistry.KeyPressRegistration>()
   package var paste = ContributedHandlerNodeRecord<LocalKeyHandlerRegistry.PasteHandler>()
 
   package init() {}
@@ -793,9 +794,9 @@ package struct NodeHandlers {
   package mutating func recordKeyPressHandler(
     identity: Identity,
     ordinal: UInt64,
-    handler: @escaping LocalKeyHandlerRegistry.KeyPressHandler
+    registration: LocalKeyHandlerRegistry.KeyPressRegistration
   ) {
-    keyHandler.keyPress.record(identity: identity, ordinal: ordinal, handler: handler)
+    keyHandler.keyPress.record(identity: identity, ordinal: ordinal, handler: registration)
   }
 
   package mutating func recordPasteHandler(

--- a/Sources/SwiftTUIGraph/Resolve/ViewGraph.swift
+++ b/Sources/SwiftTUIGraph/Resolve/ViewGraph.swift
@@ -1108,7 +1108,14 @@ package final class ViewGraph {
   ) -> [Identity] {
     var path = [identity]
     var visited: Set<Identity> = [identity]
-    var node = nodeIfExists(for: identity)
+    // Semantic controls can publish focus identities without graph nodes. Start at their nearest
+    // graph-backed owner, then use the same hosting-chain walk as every other focus identity.
+    var node: ViewNode?
+    var structuralIdentity: Identity? = identity
+    while node == nil, let candidate = structuralIdentity {
+      node = nodeIfExists(for: candidate)
+      structuralIdentity = candidate.parent
+    }
     while let current = node, path.count < limit {
       if visited.insert(current.identity).inserted {
         path.append(current.identity)

--- a/Sources/SwiftTUIGraph/Resolve/ViewNode.swift
+++ b/Sources/SwiftTUIGraph/Resolve/ViewNode.swift
@@ -1629,15 +1629,29 @@ package final class ViewNode {
   package func recordKeyPressHandlerRegistration(
     identity: Identity,
     ordinal: UInt64,
-    handler: @escaping LocalKeyHandlerRegistry.KeyPressHandler
+    registration: LocalKeyHandlerRegistry.KeyPressRegistration
   ) {
     recordRuntimeRegistrationMutation()
     registeredHandlers.recordKeyPressHandler(
       identity: identity,
       ordinal: ordinal,
-      handler: handler
+      registration: registration
     )
     refreshCommittedHandlerInventoryOutsideCapture()
+  }
+
+  package func recordKeyPressHandlerRegistration(
+    identity: Identity,
+    ordinal: UInt64,
+    handler: @escaping LocalKeyHandlerRegistry.KeyPressHandler
+  ) {
+    recordKeyPressHandlerRegistration(
+      identity: identity,
+      ordinal: ordinal,
+      registration: .init { keyPress in
+        handler(keyPress) ? .handled(focusRequest: nil) : .ignored
+      }
+    )
   }
 
   package func recordPasteHandlerRegistration(

--- a/Sources/SwiftTUIGraph/Resolve/ViewNode.swift
+++ b/Sources/SwiftTUIGraph/Resolve/ViewNode.swift
@@ -1640,20 +1640,6 @@ package final class ViewNode {
     refreshCommittedHandlerInventoryOutsideCapture()
   }
 
-  package func recordKeyPressHandlerRegistration(
-    identity: Identity,
-    ordinal: UInt64,
-    handler: @escaping LocalKeyHandlerRegistry.KeyPressHandler
-  ) {
-    recordKeyPressHandlerRegistration(
-      identity: identity,
-      ordinal: ordinal,
-      registration: .init { keyPress in
-        handler(keyPress) ? .handled(focusRequest: nil) : .ignored
-      }
-    )
-  }
-
   package func recordPasteHandlerRegistration(
     identity: Identity,
     ordinal: UInt64,

--- a/Sources/SwiftTUIGraph/Runtime/LocalKeyHandlerRegistry.swift
+++ b/Sources/SwiftTUIGraph/Runtime/LocalKeyHandlerRegistry.swift
@@ -56,50 +56,35 @@ public enum KeyEvent: Equatable, Hashable, Sendable {
   case functionKey(Int)
 }
 
-@MainActor
-private enum KeyPressDeliveryContext {
-  static var isBubbledFromSyntheticTarget = false
-
-  static func withValue<Result>(_ value: Bool, _ apply: () -> Result) -> Result {
-    let saved = isBubbledFromSyntheticTarget
-    isBubbledFromSyntheticTarget = value
-    defer { isBubbledFromSyntheticTarget = saved }
-    return apply()
-  }
-}
-
-package struct KeyPressFocusRequest: Equatable, Sendable {
-  package let identity: Identity
-  package let traversalStep: Int
-
-  package init(identity: Identity, traversalStep: Int) {
-    self.identity = identity
-    self.traversalStep = traversalStep
-  }
-}
-
 package enum KeyPressDispatchOutcome: Equatable, Sendable {
   case ignored
-  case handled(focusRequest: KeyPressFocusRequest?)
+  case handled
+  case handledAndMoveFocus(to: Identity, traversalStep: Int)
 
   package var isHandled: Bool {
-    if case .handled = self {
-      return true
+    switch self {
+    case .ignored:
+      false
+    case .handled, .handledAndMoveFocus:
+      true
     }
-    return false
   }
 }
 
 @MainActor
 package final class LocalKeyHandlerRegistry: Equatable {
-  package typealias KeyPressHandler = @MainActor (KeyPress) -> Bool
-  package typealias KeyPressOutcomeHandler = @MainActor (KeyPress) -> KeyPressDispatchOutcome
+  package typealias KeyPressHandler = @MainActor (KeyPress) -> KeyPressDispatchOutcome
   package typealias PasteHandler = @MainActor (String) -> Bool
 
   package struct KeyPressRegistration {
-    package let handler: KeyPressOutcomeHandler
+    package let receivesSyntheticBubbles: Bool
+    package let handler: KeyPressHandler
 
-    package init(handler: @escaping KeyPressOutcomeHandler) {
+    package init(
+      receivesSyntheticBubbles: Bool = true,
+      handler: @escaping KeyPressHandler
+    ) {
+      self.receivesSyntheticBubbles = receivesSyntheticBubbles
       self.handler = handler
     }
   }
@@ -164,31 +149,13 @@ package final class LocalKeyHandlerRegistry: Equatable {
 
   package func register(
     identity: Identity,
-    receivesBubbledEventsFromSyntheticTargets: Bool = true,
-    keyPressHandler: @escaping @MainActor (KeyPress) -> Bool
+    receivesSyntheticBubbles: Bool = true,
+    keyPressHandler: @escaping KeyPressHandler
   ) {
-    registerWithOutcome(
-      identity: identity,
-      receivesBubbledEventsFromSyntheticTargets: receivesBubbledEventsFromSyntheticTargets,
-      keyPressHandler: { keyPress in
-        keyPressHandler(keyPress) ? .handled(focusRequest: nil) : .ignored
-      }
+    let registration = KeyPressRegistration(
+      receivesSyntheticBubbles: receivesSyntheticBubbles,
+      handler: keyPressHandler
     )
-  }
-
-  package func registerWithOutcome(
-    identity: Identity,
-    receivesBubbledEventsFromSyntheticTargets: Bool = true,
-    keyPressHandler: @escaping KeyPressOutcomeHandler
-  ) {
-    let registration = KeyPressRegistration { keyPress in
-      if KeyPressDeliveryContext.isBubbledFromSyntheticTarget,
-        !receivesBubbledEventsFromSyntheticTargets
-      {
-        return .ignored
-      }
-      return keyPressHandler(keyPress)
-    }
     let owner = RuntimeRegistrationOwnerKey.current(identity: identity)
     let ordinal =
       keyPressHandlers[identity]?.byOwner[owner]?.ordinal ?? claimContributionOrdinal()
@@ -231,36 +198,27 @@ package final class LocalKeyHandlerRegistry: Equatable {
     identity: Identity,
     keyPress: KeyPress
   ) -> Bool {
-    dispatchWithOutcome(identity: identity, keyPress: keyPress).isHandled
+    dispatchOutcome(
+      identity: identity,
+      keyPress: keyPress,
+      isSyntheticBubble: false
+    ).isHandled
   }
 
-  package func dispatchWithOutcome(
-    identity: Identity,
-    keyPress: KeyPress
-  ) -> KeyPressDispatchOutcome {
-    KeyPressDeliveryContext.withValue(false) {
-      dispatchRegisteredHandlers(identity: identity, keyPress: keyPress)
-    }
-  }
-
-  package func dispatchBubbledWithOutcome(
+  package func dispatchOutcome(
     identity: Identity,
     keyPress: KeyPress,
-    fromSyntheticTarget: Bool
-  ) -> KeyPressDispatchOutcome {
-    KeyPressDeliveryContext.withValue(fromSyntheticTarget) {
-      dispatchRegisteredHandlers(identity: identity, keyPress: keyPress)
-    }
-  }
-
-  private func dispatchRegisteredHandlers(
-    identity: Identity,
-    keyPress: KeyPress
+    isSyntheticBubble: Bool
   ) -> KeyPressDispatchOutcome {
     guard let contributions = keyPressHandlers[identity] else {
       return .ignored
     }
     for registration in contributions.flattened.reversed() {
+      if isSyntheticBubble,
+        !registration.receivesSyntheticBubbles
+      {
+        continue
+      }
       let outcome = registration.handler(keyPress)
       if outcome.isHandled {
         return outcome
@@ -365,24 +323,6 @@ package final class LocalKeyHandlerRegistry: Equatable {
         ContributedBucket(ordinal: ordinal, handlers: handlers)
       self.ownersByIdentity[identity] = owner
     }
-  }
-
-  package func restoreKeyPressHandlers(
-    _ snapshot: [Identity: [KeyPressHandler]],
-    ownersByIdentity: [Identity: RuntimeRegistrationOwnerKey] = [:],
-    ordinalsByIdentity: [Identity: UInt64] = [:]
-  ) {
-    restoreKeyPressHandlers(
-      snapshot.mapValues { handlers in
-        handlers.map { handler in
-          KeyPressRegistration { keyPress in
-            handler(keyPress) ? .handled(focusRequest: nil) : .ignored
-          }
-        }
-      },
-      ownersByIdentity: ownersByIdentity,
-      ordinalsByIdentity: ordinalsByIdentity
-    )
   }
 
   package func restorePasteHandlers(

--- a/Sources/SwiftTUIGraph/Runtime/LocalKeyHandlerRegistry.swift
+++ b/Sources/SwiftTUIGraph/Runtime/LocalKeyHandlerRegistry.swift
@@ -58,20 +58,51 @@ public enum KeyEvent: Equatable, Hashable, Sendable {
 
 @MainActor
 private enum KeyPressDeliveryContext {
-  static var isBubbled = false
+  static var isBubbledFromSyntheticTarget = false
 
   static func withValue<Result>(_ value: Bool, _ apply: () -> Result) -> Result {
-    let saved = isBubbled
-    isBubbled = value
-    defer { isBubbled = saved }
+    let saved = isBubbledFromSyntheticTarget
+    isBubbledFromSyntheticTarget = value
+    defer { isBubbledFromSyntheticTarget = saved }
     return apply()
+  }
+}
+
+package struct KeyPressFocusRequest: Equatable, Sendable {
+  package let identity: Identity
+  package let traversalStep: Int
+
+  package init(identity: Identity, traversalStep: Int) {
+    self.identity = identity
+    self.traversalStep = traversalStep
+  }
+}
+
+package enum KeyPressDispatchOutcome: Equatable, Sendable {
+  case ignored
+  case handled(focusRequest: KeyPressFocusRequest?)
+
+  package var isHandled: Bool {
+    if case .handled = self {
+      return true
+    }
+    return false
   }
 }
 
 @MainActor
 package final class LocalKeyHandlerRegistry: Equatable {
   package typealias KeyPressHandler = @MainActor (KeyPress) -> Bool
+  package typealias KeyPressOutcomeHandler = @MainActor (KeyPress) -> KeyPressDispatchOutcome
   package typealias PasteHandler = @MainActor (String) -> Bool
+
+  package struct KeyPressRegistration {
+    package let handler: KeyPressOutcomeHandler
+
+    package init(handler: @escaping KeyPressOutcomeHandler) {
+      self.handler = handler
+    }
+  }
 
   /// One contributing owner's stacked handlers plus the persisted ordinal of
   /// the bucket's first registration. The ordinal — not the owner's
@@ -115,7 +146,7 @@ package final class LocalKeyHandlerRegistry: Equatable {
     }
   }
 
-  private var keyPressHandlers: [Identity: ContributedHandlers<KeyPressHandler>] = [:]
+  private var keyPressHandlers: [Identity: ContributedHandlers<KeyPressRegistration>] = [:]
   private var pasteHandlers: [Identity: ContributedHandlers<PasteHandler>] = [:]
   private var ownersByIdentity: [Identity: RuntimeRegistrationOwnerKey] = [:]
   /// Monotonic mint for ``ContributedBucket/ordinal``. Never reset: ordinals
@@ -133,12 +164,28 @@ package final class LocalKeyHandlerRegistry: Equatable {
 
   package func register(
     identity: Identity,
-    receivesBubbledEvents: Bool = true,
+    receivesBubbledEventsFromSyntheticTargets: Bool = true,
     keyPressHandler: @escaping @MainActor (KeyPress) -> Bool
   ) {
-    let registeredHandler: KeyPressHandler = { keyPress in
-      if KeyPressDeliveryContext.isBubbled, !receivesBubbledEvents {
-        return false
+    registerWithOutcome(
+      identity: identity,
+      receivesBubbledEventsFromSyntheticTargets: receivesBubbledEventsFromSyntheticTargets,
+      keyPressHandler: { keyPress in
+        keyPressHandler(keyPress) ? .handled(focusRequest: nil) : .ignored
+      }
+    )
+  }
+
+  package func registerWithOutcome(
+    identity: Identity,
+    receivesBubbledEventsFromSyntheticTargets: Bool = true,
+    keyPressHandler: @escaping KeyPressOutcomeHandler
+  ) {
+    let registration = KeyPressRegistration { keyPress in
+      if KeyPressDeliveryContext.isBubbledFromSyntheticTarget,
+        !receivesBubbledEventsFromSyntheticTargets
+      {
+        return .ignored
       }
       return keyPressHandler(keyPress)
     }
@@ -147,12 +194,12 @@ package final class LocalKeyHandlerRegistry: Equatable {
       keyPressHandlers[identity]?.byOwner[owner]?.ordinal ?? claimContributionOrdinal()
     keyPressHandlers[identity, default: .init()]
       .byOwner[owner, default: ContributedBucket(ordinal: ordinal, handlers: [])]
-      .handlers.append(registeredHandler)
+      .handlers.append(registration)
     ownersByIdentity[identity] = owner
     ViewNodeContext.current?.recordKeyPressHandlerRegistration(
       identity: identity,
       ordinal: ordinal,
-      handler: registeredHandler
+      registration: registration
     )
   }
 
@@ -184,17 +231,24 @@ package final class LocalKeyHandlerRegistry: Equatable {
     identity: Identity,
     keyPress: KeyPress
   ) -> Bool {
+    dispatchWithOutcome(identity: identity, keyPress: keyPress).isHandled
+  }
+
+  package func dispatchWithOutcome(
+    identity: Identity,
+    keyPress: KeyPress
+  ) -> KeyPressDispatchOutcome {
     KeyPressDeliveryContext.withValue(false) {
       dispatchRegisteredHandlers(identity: identity, keyPress: keyPress)
     }
   }
 
-  @discardableResult
-  package func dispatchBubbled(
+  package func dispatchBubbledWithOutcome(
     identity: Identity,
-    keyPress: KeyPress
-  ) -> Bool {
-    KeyPressDeliveryContext.withValue(true) {
+    keyPress: KeyPress,
+    fromSyntheticTarget: Bool
+  ) -> KeyPressDispatchOutcome {
+    KeyPressDeliveryContext.withValue(fromSyntheticTarget) {
       dispatchRegisteredHandlers(identity: identity, keyPress: keyPress)
     }
   }
@@ -202,16 +256,17 @@ package final class LocalKeyHandlerRegistry: Equatable {
   private func dispatchRegisteredHandlers(
     identity: Identity,
     keyPress: KeyPress
-  ) -> Bool {
+  ) -> KeyPressDispatchOutcome {
     guard let contributions = keyPressHandlers[identity] else {
-      return false
+      return .ignored
     }
-    for handler in contributions.flattened.reversed() {
-      if handler(keyPress) {
-        return true
+    for registration in contributions.flattened.reversed() {
+      let outcome = registration.handler(keyPress)
+      if outcome.isHandled {
+        return outcome
       }
     }
-    return false
+    return .ignored
   }
 
   @discardableResult
@@ -277,7 +332,7 @@ package final class LocalKeyHandlerRegistry: Equatable {
     }
   }
 
-  package func snapshotKeyPressHandlers() -> [Identity: [KeyPressHandler]] {
+  package func snapshotKeyPressHandlers() -> [Identity: [KeyPressRegistration]] {
     keyPressHandlers.mapValues(\.flattened)
   }
 
@@ -286,7 +341,7 @@ package final class LocalKeyHandlerRegistry: Equatable {
   }
 
   package func restoreKeyPressHandlers(
-    _ snapshot: [Identity: [KeyPressHandler]],
+    _ snapshot: [Identity: [KeyPressRegistration]],
     ownersByIdentity: [Identity: RuntimeRegistrationOwnerKey] = [:],
     ordinalsByIdentity: [Identity: UInt64] = [:]
   ) {
@@ -310,6 +365,24 @@ package final class LocalKeyHandlerRegistry: Equatable {
         ContributedBucket(ordinal: ordinal, handlers: handlers)
       self.ownersByIdentity[identity] = owner
     }
+  }
+
+  package func restoreKeyPressHandlers(
+    _ snapshot: [Identity: [KeyPressHandler]],
+    ownersByIdentity: [Identity: RuntimeRegistrationOwnerKey] = [:],
+    ordinalsByIdentity: [Identity: UInt64] = [:]
+  ) {
+    restoreKeyPressHandlers(
+      snapshot.mapValues { handlers in
+        handlers.map { handler in
+          KeyPressRegistration { keyPress in
+            handler(keyPress) ? .handled(focusRequest: nil) : .ignored
+          }
+        }
+      },
+      ownersByIdentity: ownersByIdentity,
+      ordinalsByIdentity: ordinalsByIdentity
+    )
   }
 
   package func restorePasteHandlers(

--- a/Sources/SwiftTUIGraph/Runtime/LocalKeyHandlerRegistry.swift
+++ b/Sources/SwiftTUIGraph/Runtime/LocalKeyHandlerRegistry.swift
@@ -57,6 +57,18 @@ public enum KeyEvent: Equatable, Hashable, Sendable {
 }
 
 @MainActor
+private enum KeyPressDeliveryContext {
+  static var isBubbled = false
+
+  static func withValue<Result>(_ value: Bool, _ apply: () -> Result) -> Result {
+    let saved = isBubbled
+    isBubbled = value
+    defer { isBubbled = saved }
+    return apply()
+  }
+}
+
+@MainActor
 package final class LocalKeyHandlerRegistry: Equatable {
   package typealias KeyPressHandler = @MainActor (KeyPress) -> Bool
   package typealias PasteHandler = @MainActor (String) -> Bool
@@ -121,19 +133,26 @@ package final class LocalKeyHandlerRegistry: Equatable {
 
   package func register(
     identity: Identity,
-    keyPressHandler: @escaping KeyPressHandler
+    receivesBubbledEvents: Bool = true,
+    keyPressHandler: @escaping @MainActor (KeyPress) -> Bool
   ) {
+    let registeredHandler: KeyPressHandler = { keyPress in
+      if KeyPressDeliveryContext.isBubbled, !receivesBubbledEvents {
+        return false
+      }
+      return keyPressHandler(keyPress)
+    }
     let owner = RuntimeRegistrationOwnerKey.current(identity: identity)
     let ordinal =
       keyPressHandlers[identity]?.byOwner[owner]?.ordinal ?? claimContributionOrdinal()
     keyPressHandlers[identity, default: .init()]
       .byOwner[owner, default: ContributedBucket(ordinal: ordinal, handlers: [])]
-      .handlers.append(keyPressHandler)
+      .handlers.append(registeredHandler)
     ownersByIdentity[identity] = owner
     ViewNodeContext.current?.recordKeyPressHandlerRegistration(
       identity: identity,
       ordinal: ordinal,
-      handler: keyPressHandler
+      handler: registeredHandler
     )
   }
 
@@ -162,6 +181,25 @@ package final class LocalKeyHandlerRegistry: Equatable {
 
   @discardableResult
   package func dispatch(
+    identity: Identity,
+    keyPress: KeyPress
+  ) -> Bool {
+    KeyPressDeliveryContext.withValue(false) {
+      dispatchRegisteredHandlers(identity: identity, keyPress: keyPress)
+    }
+  }
+
+  @discardableResult
+  package func dispatchBubbled(
+    identity: Identity,
+    keyPress: KeyPress
+  ) -> Bool {
+    KeyPressDeliveryContext.withValue(true) {
+      dispatchRegisteredHandlers(identity: identity, keyPress: keyPress)
+    }
+  }
+
+  private func dispatchRegisteredHandlers(
     identity: Identity,
     keyPress: KeyPress
   ) -> Bool {

--- a/Sources/SwiftTUIRuntime/RunLoop/RunLoop+EventDispatch.swift
+++ b/Sources/SwiftTUIRuntime/RunLoop/RunLoop+EventDispatch.swift
@@ -83,31 +83,29 @@ extension RunLoop {
     from focusedIdentity: Identity
   ) -> Bool {
     let invalidationGenerationBeforeDispatch = schedulerInvalidationRequestGeneration()
-    let fromSyntheticTarget = !renderer.viewGraph.containsNode(for: focusedIdentity)
+    let focusedTargetIsSynthetic = !renderer.viewGraph.containsNode(for: focusedIdentity)
     for identity in renderer.viewGraph.keyEventBubblePath(from: focusedIdentity)
     where localKeyHandlerRegistry.hasHandler(identity: identity) {
-      let outcome =
-        if identity == focusedIdentity {
-          localKeyHandlerRegistry.dispatchWithOutcome(identity: identity, keyPress: keyPress)
-        } else {
-          localKeyHandlerRegistry.dispatchBubbledWithOutcome(
-            identity: identity,
-            keyPress: keyPress,
-            fromSyntheticTarget: fromSyntheticTarget
-          )
+      let outcome = localKeyHandlerRegistry.dispatchOutcome(
+        identity: identity,
+        keyPress: keyPress,
+        isSyntheticBubble: focusedTargetIsSynthetic && identity != focusedIdentity
+      )
+      switch outcome {
+      case .ignored:
+        continue
+      case .handled:
+        break
+      case .handledAndMoveFocus(let targetIdentity, let traversalStep):
+        performFocusTraversal(step: traversalStep) {
+          _ = focusTracker.setFocus(to: targetIdentity)
+          return focusTracker.currentFocusIdentity
         }
-      if case .handled(let focusRequest) = outcome {
-        if let focusRequest {
-          performFocusTraversal(step: focusRequest.traversalStep) {
-            _ = focusTracker.setFocus(to: focusRequest.identity)
-            return focusTracker.currentFocusIdentity
-          }
-        }
-        requestDispatchBackstopInvalidation(
-          schedulerInvalidationGenerationBeforeDispatch: invalidationGenerationBeforeDispatch
-        )
-        return true
       }
+      requestDispatchBackstopInvalidation(
+        schedulerInvalidationGenerationBeforeDispatch: invalidationGenerationBeforeDispatch
+      )
+      return true
     }
     return false
   }

--- a/Sources/SwiftTUIRuntime/RunLoop/RunLoop+EventDispatch.swift
+++ b/Sources/SwiftTUIRuntime/RunLoop/RunLoop+EventDispatch.swift
@@ -85,7 +85,13 @@ extension RunLoop {
     let invalidationGenerationBeforeDispatch = schedulerInvalidationRequestGeneration()
     for identity in renderer.viewGraph.keyEventBubblePath(from: focusedIdentity)
     where localKeyHandlerRegistry.hasHandler(identity: identity) {
-      if localKeyHandlerRegistry.dispatch(identity: identity, keyPress: keyPress) {
+      let handled =
+        if identity == focusedIdentity {
+          localKeyHandlerRegistry.dispatch(identity: identity, keyPress: keyPress)
+        } else {
+          localKeyHandlerRegistry.dispatchBubbled(identity: identity, keyPress: keyPress)
+        }
+      if handled {
         requestDispatchBackstopInvalidation(
           schedulerInvalidationGenerationBeforeDispatch: invalidationGenerationBeforeDispatch
         )

--- a/Sources/SwiftTUIRuntime/RunLoop/RunLoop+EventDispatch.swift
+++ b/Sources/SwiftTUIRuntime/RunLoop/RunLoop+EventDispatch.swift
@@ -83,15 +83,26 @@ extension RunLoop {
     from focusedIdentity: Identity
   ) -> Bool {
     let invalidationGenerationBeforeDispatch = schedulerInvalidationRequestGeneration()
+    let fromSyntheticTarget = !renderer.viewGraph.containsNode(for: focusedIdentity)
     for identity in renderer.viewGraph.keyEventBubblePath(from: focusedIdentity)
     where localKeyHandlerRegistry.hasHandler(identity: identity) {
-      let handled =
+      let outcome =
         if identity == focusedIdentity {
-          localKeyHandlerRegistry.dispatch(identity: identity, keyPress: keyPress)
+          localKeyHandlerRegistry.dispatchWithOutcome(identity: identity, keyPress: keyPress)
         } else {
-          localKeyHandlerRegistry.dispatchBubbled(identity: identity, keyPress: keyPress)
+          localKeyHandlerRegistry.dispatchBubbledWithOutcome(
+            identity: identity,
+            keyPress: keyPress,
+            fromSyntheticTarget: fromSyntheticTarget
+          )
         }
-      if handled {
+      if case .handled(let focusRequest) = outcome {
+        if let focusRequest {
+          performFocusTraversal(step: focusRequest.traversalStep) {
+            _ = focusTracker.setFocus(to: focusRequest.identity)
+            return focusTracker.currentFocusIdentity
+          }
+        }
         requestDispatchBackstopInvalidation(
           schedulerInvalidationGenerationBeforeDispatch: invalidationGenerationBeforeDispatch
         )

--- a/Sources/SwiftTUIViews/Collections/List.swift
+++ b/Sources/SwiftTUIViews/Collections/List.swift
@@ -225,7 +225,7 @@ extension List {
 
       intake.registerKeyPressHandler(
         identity: context.identity,
-        receivesBubbledEventsFromSyntheticTargets: false
+        receivesSyntheticBubbles: false
       ) { keyPress in
         guard keyPress.modifiers.isEmpty else {
           return false
@@ -345,11 +345,9 @@ extension List {
             // Selection and focus are one control action. Returning ignored
             // after changing selection lets an ancestor consume the arrow
             // before the runtime moves focus, leaving the two out of sync.
-            return .handled(
-              focusRequest: .init(
-                identity: listRowIdentity(for: context.identity, rowIndex: targetIndex),
-                traversalStep: delta
-              )
+            return .handledAndMoveFocus(
+              to: listRowIdentity(for: context.identity, rowIndex: targetIndex),
+              traversalStep: delta
             )
           }
         }

--- a/Sources/SwiftTUIViews/Collections/List.swift
+++ b/Sources/SwiftTUIViews/Collections/List.swift
@@ -223,7 +223,10 @@ extension List {
         }
       }
 
-      intake.registerKeyPressHandler(identity: context.identity) { keyPress in
+      intake.registerKeyPressHandler(
+        identity: context.identity,
+        receivesBubbledEvents: false
+      ) { keyPress in
         guard keyPress.modifiers.isEmpty else {
           return false
         }

--- a/Sources/SwiftTUIViews/Collections/List.swift
+++ b/Sources/SwiftTUIViews/Collections/List.swift
@@ -325,14 +325,11 @@ extension List {
               return .ignored
             }
 
-            let targetIndex = min(
-              max(rowIndex + delta, rows.startIndex),
-              rows.index(before: rows.endIndex)
-            )
-            guard targetIndex != rowIndex else {
-              return .ignored
+            var targetIndex = rowIndex + delta
+            while rows.indices.contains(targetIndex), rows[targetIndex].tag == nil {
+              targetIndex += delta
             }
-            guard let targetTag = rows[targetIndex].tag else {
+            guard rows.indices.contains(targetIndex), let targetTag = rows[targetIndex].tag else {
               return .ignored
             }
             if !policy.isMultiple {

--- a/Sources/SwiftTUIViews/Collections/List.swift
+++ b/Sources/SwiftTUIViews/Collections/List.swift
@@ -225,7 +225,7 @@ extension List {
 
       intake.registerKeyPressHandler(
         identity: context.identity,
-        receivesBubbledEvents: false
+        receivesBubbledEventsFromSyntheticTargets: false
       ) { keyPress in
         guard keyPress.modifiers.isEmpty else {
           return false
@@ -307,9 +307,9 @@ extension List {
           intake.registerAction(identity: rowIdentity) {
             policy.isMultiple ? policy.toggle(tag) : activate(tag)
           }
-          intake.registerKeyPressHandler(identity: rowIdentity) { keyPress in
+          intake.registerKeyPressOutcomeHandler(identity: rowIdentity) { keyPress in
             guard keyPress.modifiers.isEmpty else {
-              return false
+              return .ignored
             }
             let delta: Int?
             switch keyPress.key {
@@ -322,29 +322,38 @@ extension List {
             }
 
             guard let delta, !rows.isEmpty else {
-              return false
+              return .ignored
             }
 
             let targetIndex = min(
               max(rowIndex + delta, rows.startIndex),
               rows.index(before: rows.endIndex)
             )
+            guard targetIndex != rowIndex else {
+              return .ignored
+            }
             guard let targetTag = rows[targetIndex].tag else {
-              return false
+              return .ignored
             }
             if !policy.isMultiple {
               _ = policy.select(targetTag)
             }
             if let scrollCurrency {
-              // This handler owns the common case: with focus on a row, the
-              // row's own handler sees the arrow and the container's never
-              // does. Pin before revealing — while nothing is stored the
-              // window IS the selection, so a minimal reveal would just be
-              // re-centred by the fallback underneath it.
+              // Pin before revealing — while nothing is stored the window IS
+              // the selection, so a minimal reveal would just be re-centred
+              // by the fallback underneath it.
               scrollCurrency.pinCurrentAnchor()
               scrollCurrency.reveal(row: targetIndex)
             }
-            return false
+            // Selection and focus are one control action. Returning ignored
+            // after changing selection lets an ancestor consume the arrow
+            // before the runtime moves focus, leaving the two out of sync.
+            return .handled(
+              focusRequest: .init(
+                identity: listRowIdentity(for: context.identity, rowIndex: targetIndex),
+                traversalStep: delta
+              )
+            )
           }
         }
       }

--- a/Sources/SwiftTUIViews/State/HandlerDescriptorIntake.swift
+++ b/Sources/SwiftTUIViews/State/HandlerDescriptorIntake.swift
@@ -172,11 +172,13 @@ package struct HandlerDescriptorIntake {
 
   package func registerKeyPressHandler(
     identity: Identity,
+    receivesBubbledEvents: Bool = true,
     handler: @escaping @MainActor (KeyPress) -> Bool
   ) {
     let scope = dispatchScope
     context.localKeyHandlerRegistry?.register(
       identity: identity,
+      receivesBubbledEvents: receivesBubbledEvents,
       keyPressHandler: { press in
         withImperativeAuthoringContext(scope) {
           handler(press)

--- a/Sources/SwiftTUIViews/State/HandlerDescriptorIntake.swift
+++ b/Sources/SwiftTUIViews/State/HandlerDescriptorIntake.swift
@@ -172,28 +172,27 @@ package struct HandlerDescriptorIntake {
 
   package func registerKeyPressHandler(
     identity: Identity,
-    receivesBubbledEventsFromSyntheticTargets: Bool = true,
+    receivesSyntheticBubbles: Bool = true,
     handler: @escaping @MainActor (KeyPress) -> Bool
   ) {
-    let scope = dispatchScope
-    context.localKeyHandlerRegistry?.register(
+    registerKeyPressOutcomeHandler(
       identity: identity,
-      receivesBubbledEventsFromSyntheticTargets: receivesBubbledEventsFromSyntheticTargets,
-      keyPressHandler: { press in
-        withImperativeAuthoringContext(scope) {
-          handler(press)
-        }
+      receivesSyntheticBubbles: receivesSyntheticBubbles,
+      handler: { press in
+        handler(press) ? .handled : .ignored
       }
     )
   }
 
   package func registerKeyPressOutcomeHandler(
     identity: Identity,
+    receivesSyntheticBubbles: Bool = true,
     handler: @escaping @MainActor (KeyPress) -> KeyPressDispatchOutcome
   ) {
     let scope = dispatchScope
-    context.localKeyHandlerRegistry?.registerWithOutcome(
+    context.localKeyHandlerRegistry?.register(
       identity: identity,
+      receivesSyntheticBubbles: receivesSyntheticBubbles,
       keyPressHandler: { press in
         withImperativeAuthoringContext(scope) {
           handler(press)

--- a/Sources/SwiftTUIViews/State/HandlerDescriptorIntake.swift
+++ b/Sources/SwiftTUIViews/State/HandlerDescriptorIntake.swift
@@ -172,13 +172,28 @@ package struct HandlerDescriptorIntake {
 
   package func registerKeyPressHandler(
     identity: Identity,
-    receivesBubbledEvents: Bool = true,
+    receivesBubbledEventsFromSyntheticTargets: Bool = true,
     handler: @escaping @MainActor (KeyPress) -> Bool
   ) {
     let scope = dispatchScope
     context.localKeyHandlerRegistry?.register(
       identity: identity,
-      receivesBubbledEvents: receivesBubbledEvents,
+      receivesBubbledEventsFromSyntheticTargets: receivesBubbledEventsFromSyntheticTargets,
+      keyPressHandler: { press in
+        withImperativeAuthoringContext(scope) {
+          handler(press)
+        }
+      }
+    )
+  }
+
+  package func registerKeyPressOutcomeHandler(
+    identity: Identity,
+    handler: @escaping @MainActor (KeyPress) -> KeyPressDispatchOutcome
+  ) {
+    let scope = dispatchScope
+    context.localKeyHandlerRegistry?.registerWithOutcome(
+      identity: identity,
       keyPressHandler: { press in
         withImperativeAuthoringContext(scope) {
           handler(press)

--- a/Tests/SwiftTUICoreTests/Pointer/RoutePairingRegistryTests.swift
+++ b/Tests/SwiftTUICoreTests/Pointer/RoutePairingRegistryTests.swift
@@ -162,9 +162,9 @@ struct RoutePairingRegistryTests {
     registry.restoreKeyPressHandlers(
       [
         identity: [
-          { _ in
+          .init { _ in
             received.append("inner")
-            return true
+            return .handled
           }
         ]
       ],
@@ -174,9 +174,9 @@ struct RoutePairingRegistryTests {
     registry.restoreKeyPressHandlers(
       [
         identity: [
-          { _ in
+          .init { _ in
             received.append("outer")
-            return true
+            return .handled
           }
         ]
       ],
@@ -201,9 +201,9 @@ struct RoutePairingRegistryTests {
     registry.restoreKeyPressHandlers(
       [
         identity: [
-          { _ in
+          .init { _ in
             received.append("inner")
-            return true
+            return .handled
           }
         ]
       ],
@@ -213,9 +213,9 @@ struct RoutePairingRegistryTests {
     registry.restoreKeyPressHandlers(
       [
         identity: [
-          { _ in
+          .init { _ in
             received.append("outer")
-            return true
+            return .handled
           }
         ]
       ],
@@ -291,9 +291,9 @@ struct RoutePairingRegistryTests {
     registry.restoreKeyPressHandlers(
       [
         identity: [
-          { _ in
+          .init { _ in
             received.append("restored")
-            return true
+            return .handled
           }
         ]
       ],
@@ -306,7 +306,7 @@ struct RoutePairingRegistryTests {
       identity: identity,
       keyPressHandler: { _ in
         received.append("fresh")
-        return true
+        return .handled
       }
     )
 

--- a/Tests/SwiftTUIGraphTests/CommittedHandlerInventoryTests.swift
+++ b/Tests/SwiftTUIGraphTests/CommittedHandlerInventoryTests.swift
@@ -51,7 +51,11 @@ struct CommittedHandlerInventoryTests {
         handler: { false },
         followUpInvalidationIdentity: nil
       )
-      node.recordKeyPressHandlerRegistration(identity: pressKey, ordinal: 0) { _ in false }
+      node.recordKeyPressHandlerRegistration(
+        identity: pressKey,
+        ordinal: 0,
+        registration: .init { _ in .ignored }
+      )
       node.recordPasteHandlerRegistration(identity: pasteKey, ordinal: 0) { _ in false }
       node.recordCommandRegistration(
         commandSnapshot(scope: commandScope)

--- a/Tests/SwiftTUIGraphTests/CommittedHandlerResolutionOracleTests.swift
+++ b/Tests/SwiftTUIGraphTests/CommittedHandlerResolutionOracleTests.swift
@@ -302,7 +302,7 @@ struct CommittedHandlerResolutionOracleTests {
       registrations.actionRegistry?.register(identity: action) { false }
       registrations.keyHandlerRegistry?.register(
         identity: key,
-        keyPressHandler: { _ in false }
+        keyPressHandler: { _ in .ignored }
       )
       registrations.commandRegistry?.registerKeyCommand(
         at: command,

--- a/Tests/SwiftTUIGraphTests/DuplicateRegistrationProbeTests.swift
+++ b/Tests/SwiftTUIGraphTests/DuplicateRegistrationProbeTests.swift
@@ -109,8 +109,16 @@ struct DuplicateRegistrationProbeTests {
     withArmedProbe {
       let before = alarmCount
       ViewNodeContext.withValue(node) {
-        node.recordKeyPressHandlerRegistration(identity: identity, ordinal: 0) { _ in false }
-        node.recordKeyPressHandlerRegistration(identity: identity, ordinal: 0) { _ in false }
+        node.recordKeyPressHandlerRegistration(
+          identity: identity,
+          ordinal: 0,
+          registration: .init { _ in .ignored }
+        )
+        node.recordKeyPressHandlerRegistration(
+          identity: identity,
+          ordinal: 0,
+          registration: .init { _ in .ignored }
+        )
       }
       #expect(alarmCount == before, "contributed families append by design")
     }

--- a/Tests/SwiftTUIGraphTests/FrameDropEligibilityBlockerTests.swift
+++ b/Tests/SwiftTUIGraphTests/FrameDropEligibilityBlockerTests.swift
@@ -19,7 +19,7 @@ struct FrameDropEligibilityBlockerTests {
     let registry = LocalKeyHandlerRegistry()
     #expect(registry.activeFrameDropEligibilityBlocker == nil)
 
-    registry.register(identity: testIdentity("Root", "Field"), keyPressHandler: { _ in false })
+    registry.register(identity: testIdentity("Root", "Field"), keyPressHandler: { _ in .ignored })
     #expect(registry.activeFrameDropEligibilityBlocker == .handlerInstallations)
   }
 

--- a/Tests/SwiftTUIGraphTests/RegistrationKindTestSupport.swift
+++ b/Tests/SwiftTUIGraphTests/RegistrationKindTestSupport.swift
@@ -47,7 +47,11 @@ enum RegistrationKindDriver {
         followUpInvalidationIdentity: nil
       )
     case .keyHandler:
-      node.recordKeyPressHandlerRegistration(identity: identity, ordinal: 0) { _ in false }
+      node.recordKeyPressHandlerRegistration(
+        identity: identity,
+        ordinal: 0,
+        registration: .init { _ in .ignored }
+      )
       node.recordPasteHandlerRegistration(identity: identity, ordinal: 0) { _ in false }
     case .termination:
       node.recordTerminationHandlerRegistration(identity: identity) { _ in .allow }

--- a/Tests/SwiftTUIGraphTests/RuntimeRegistrationRestoreScopingTests.swift
+++ b/Tests/SwiftTUIGraphTests/RuntimeRegistrationRestoreScopingTests.swift
@@ -402,7 +402,11 @@ struct RuntimeRegistrationRestoreScopingTests {
         handler: { true },
         followUpInvalidationIdentity: nil
       )
-      customNode.recordKeyPressHandlerRegistration(identity: pinned, ordinal: 0) { _ in true }
+      customNode.recordKeyPressHandlerRegistration(
+        identity: pinned,
+        ordinal: 0,
+        registration: .init { _ in .handled }
+      )
     }
     customNode.endRegistrationCapture()
     graph.finishEvaluation(
@@ -512,7 +516,11 @@ struct RuntimeRegistrationRestoreScopingTests {
     let departingNode = graph.beginEvaluation(identity: departingIdentity, invalidator: nil)
     departingNode.beginRegistrationCapture()
     ViewNodeContext.withValue(departingNode) {
-      departingNode.recordKeyPressHandlerRegistration(identity: pinned, ordinal: 0) { _ in true }
+      departingNode.recordKeyPressHandlerRegistration(
+        identity: pinned,
+        ordinal: 0,
+        registration: .init { _ in .handled }
+      )
       departingNode.recordScrollPositionRegistration(
         .init(identity: departingIdentity, currentOffset: { .zero }, applyOffset: { _ in }))
     }
@@ -553,7 +561,11 @@ struct RuntimeRegistrationRestoreScopingTests {
     let arrivingNode = graph.beginEvaluation(identity: arrivingIdentity, invalidator: nil)
     arrivingNode.beginRegistrationCapture()
     ViewNodeContext.withValue(arrivingNode) {
-      arrivingNode.recordKeyPressHandlerRegistration(identity: pinned, ordinal: 0) { _ in true }
+      arrivingNode.recordKeyPressHandlerRegistration(
+        identity: pinned,
+        ordinal: 0,
+        registration: .init { _ in .handled }
+      )
       arrivingNode.recordScrollPositionRegistration(
         .init(identity: arrivingIdentity, currentOffset: { .zero }, applyOffset: { _ in }))
     }
@@ -2301,9 +2313,11 @@ struct RuntimeRegistrationRestoreScopingTests {
         handler: { marker.hasSuffix("1") },
         followUpInvalidationIdentity: identity.child("follow-up-\(marker)")
       )
-      node.recordKeyPressHandlerRegistration(identity: identity, ordinal: 0) { _ in
-        marker.hasSuffix("1")
-      }
+      node.recordKeyPressHandlerRegistration(
+        identity: identity,
+        ordinal: 0,
+        registration: .init { _ in marker.hasSuffix("1") ? .handled : .ignored }
+      )
       node.recordPasteHandlerRegistration(identity: identity, ordinal: 0) { _ in
         marker.hasSuffix("1")
       }

--- a/Tests/SwiftTUITests/CollectionScrollCurrencyTests.swift
+++ b/Tests/SwiftTUITests/CollectionScrollCurrencyTests.swift
@@ -27,7 +27,7 @@ struct CollectionScrollCurrencyTests {
 
     // Arrow keys are selection keys, so they need focus inside the list. A
     // click on a visible row is how a user gets there.
-    _ = try harness.clickText("«0»")
+    _ = try harness.focusText("«0»")
     var previousRows = scrollCurrencyRows(harness.frame)
     #expect(previousRows.contains(0))
     #expect(previousRows.count > 3)
@@ -155,6 +155,30 @@ struct CollectionScrollCurrencyTests {
     let afterPage = try #require(scrollCurrencyRows(harness.frame).min())
     #expect(afterPage > 0, "PageDown advances a screenful")
     #expect(afterPage <= afterHome + 1, "PageDown advances at most one screenful")
+  }
+
+  @Test("List scroll keys bubble from nested controls")
+  func listScrollKeysBubbleFromNestedControls() throws {
+    let harness = try StressRuntimeHarness(
+      rootIdentity: testIdentity("ScrollCurrencyNestedControl"),
+      size: .init(width: 30, height: 12)
+    ) {
+      NestedControlCurrencyList()
+    }
+    defer { harness.shutdown() }
+
+    _ = try harness.clickText("«0»")
+    #expect(
+      harness.runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow") == false,
+      "the nested Button, not its synthetic row, must own focus"
+    )
+    #expect(scrollCurrencyRows(harness.frame).contains(0))
+
+    _ = try harness.pressKey(KeyPress(.pageDown))
+    #expect(
+      !scrollCurrencyRows(harness.frame).contains(0),
+      "the List fallback must scroll after the nested control ignores PageDown"
+    )
   }
 
   @Test("T-04: scrollTo(id) is a no-op in-window and reveals an out-of-window row")
@@ -345,6 +369,18 @@ private struct NonSelectableCurrencyList: View {
   var body: some View {
     List(0..<10_000, id: \.self) { row in
       Text("«\(row)»")
+    }
+    .frame(height: 10)
+  }
+}
+
+@MainActor
+private struct NestedControlCurrencyList: View {
+  @State private var selection: Int? = 0
+
+  var body: some View {
+    List(0..<100, id: \.self, selection: $selection) { row in
+      Button("«\(row)»") {}
     }
     .frame(height: 10)
   }

--- a/Tests/SwiftTUITests/CollectionScrollCurrencyTests.swift
+++ b/Tests/SwiftTUITests/CollectionScrollCurrencyTests.swift
@@ -27,7 +27,7 @@ struct CollectionScrollCurrencyTests {
 
     // Arrow keys are selection keys, so they need focus inside the list. A
     // click on a visible row is how a user gets there.
-    _ = try harness.focusText("«0»")
+    _ = try harness.clickText("«0»")
     var previousRows = scrollCurrencyRows(harness.frame)
     #expect(previousRows.contains(0))
     #expect(previousRows.count > 3)
@@ -167,7 +167,7 @@ struct CollectionScrollCurrencyTests {
     }
     defer { harness.shutdown() }
 
-    _ = try harness.clickText("«0»")
+    _ = try harness.focusText("«0»")
     #expect(
       harness.runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow") == false,
       "the nested Button, not its synthetic row, must own focus"

--- a/Tests/SwiftTUITests/InteractiveRuntimeTests.swift
+++ b/Tests/SwiftTUITests/InteractiveRuntimeTests.swift
@@ -5315,7 +5315,7 @@ private struct ReusedHandlerProbe: PrimitiveView, ResolvableView {
       identity: context.identity,
       keyPressHandler: { keyPress in
         recorder.recordKey(keyPress.key)
-        return true
+        return .handled
       }
     )
     return [interactiveProbeTextNode("Interactive", in: context)]

--- a/Tests/SwiftTUITests/KeyCommandTests.swift
+++ b/Tests/SwiftTUITests/KeyCommandTests.swift
@@ -475,9 +475,10 @@ struct KeyCommandDispatchTests {
     let model = ListSelectionModel()
     let runLoop = makeRunLoop {
       List(selection: Binding(get: { model.selection }, set: { model.selection = $0 })) {
-        ForEach(0..<3) { index in
-          Text("row \(index)").tag(index)
-        }
+        Text("row 0").tag(0)
+        Text("separator")
+        Text("row 1").tag(1)
+        Text("row 2").tag(2)
       }
       .onKeyPress(.arrowDown) { _ in
         model.receivedArrowCount += 1
@@ -491,11 +492,11 @@ struct KeyCommandDispatchTests {
 
     #expect(model.receivedArrowCount == 0)
     #expect(model.selection == 1)
-    #expect(runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow[1]") == true)
+    #expect(runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow[2]") == true)
 
     let lastRow = try #require(
       runLoop.focusTracker.focusRegions.first {
-        $0.identity.description.contains("ListRow[2]")
+        $0.identity.description.contains("ListRow[3]")
       }?.identity
     )
     _ = runLoop.focusTracker.setFocus(to: lastRow)

--- a/Tests/SwiftTUITests/KeyCommandTests.swift
+++ b/Tests/SwiftTUITests/KeyCommandTests.swift
@@ -444,6 +444,30 @@ struct KeyCommandDispatchTests {
     #expect(surfaceText.contains("Open"))
     #expect(!surfaceText.contains("detail"))
   }
+
+  @Test("List rows bubble consumer keys without double-dispatching navigation")
+  func listConsumerHandlerReceivesFocusedRowKeys() throws {
+    let model = ListSelectionModel()
+    let runLoop = makeRunLoop {
+      List(selection: Binding(get: { model.selection }, set: { model.selection = $0 })) {
+        ForEach(0..<3) { index in
+          Text("row \(index)").tag(index)
+        }
+      }
+      .onKeyPress(.space) { _ in
+        model.receivedKeyCount += 1
+        return .handled
+      }
+    }
+    try renderInitial(runLoop)
+
+    #expect(runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow[0]") == true)
+    _ = runLoop.handle(.input(.key(.space)))
+    #expect(model.receivedKeyCount == 1)
+
+    _ = runLoop.handle(.input(.key(.arrowDown)))
+    #expect(model.selection == 1)
+  }
 }
 
 @MainActor
@@ -497,6 +521,12 @@ private func renderInitial<State, V: View>(_ runLoop: RunLoop<State, V>) throws 
 final class Counter {
   private(set) var count = 0
   func increment() { count += 1 }
+}
+
+@MainActor
+private final class ListSelectionModel {
+  var selection = 0
+  var receivedKeyCount = 0
 }
 
 @MainActor

--- a/Tests/SwiftTUITests/KeyCommandTests.swift
+++ b/Tests/SwiftTUITests/KeyCommandTests.swift
@@ -467,6 +467,44 @@ struct KeyCommandDispatchTests {
 
     _ = runLoop.handle(.input(.key(.arrowDown)))
     #expect(model.selection == 1)
+    #expect(runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow[1]") == true)
+  }
+
+  @Test("List row navigation completes before ancestor key handlers")
+  func listRowNavigationPrecedesConsumerHandler() throws {
+    let model = ListSelectionModel()
+    let runLoop = makeRunLoop {
+      List(selection: Binding(get: { model.selection }, set: { model.selection = $0 })) {
+        ForEach(0..<3) { index in
+          Text("row \(index)").tag(index)
+        }
+      }
+      .onKeyPress(.arrowDown) { _ in
+        model.receivedArrowCount += 1
+        return .handled
+      }
+    }
+    try renderInitial(runLoop)
+
+    #expect(runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow[0]") == true)
+    _ = runLoop.handle(.input(.key(.arrowDown)))
+
+    #expect(model.receivedArrowCount == 0)
+    #expect(model.selection == 1)
+    #expect(runLoop.focusTracker.currentFocusIdentity?.description.contains("ListRow[1]") == true)
+
+    let lastRow = try #require(
+      runLoop.focusTracker.focusRegions.first {
+        $0.identity.description.contains("ListRow[2]")
+      }?.identity
+    )
+    _ = runLoop.focusTracker.setFocus(to: lastRow)
+    model.selection = 2
+    _ = runLoop.handle(.input(.key(.arrowDown)))
+
+    #expect(model.receivedArrowCount == 1)
+    #expect(model.selection == 2)
+    #expect(runLoop.focusTracker.currentFocusIdentity == lastRow)
   }
 }
 
@@ -527,6 +565,7 @@ final class Counter {
 private final class ListSelectionModel {
   var selection = 0
   var receivedKeyCount = 0
+  var receivedArrowCount = 0
 }
 
 @MainActor


### PR DESCRIPTION
## Problem

Some semantic controls, including `List` rows, expose focus identities without corresponding `ViewGraph` nodes. Key events therefore stopped at the synthetic target instead of bubbling through its graph-backed owner.

Naively extending the bubble path caused two further problems:

- A row could update selection before an ancestor consumed the arrow key, leaving selection and focus out of sync.
- Suppressing all bubbled events at the `List` prevented scrolling keys from working when a nested control owned focus.

## Solution

- Continue bubbling from synthetic focus identities through their nearest graph-backed owner.
- Explicitly mark events bubbling from synthetic targets.
- Store whether each handler accepts synthetic-origin bubbles with its registration.
- Give internal key handlers three outcomes:
  - ignored
  - handled
  - handled with a focus move
- Apply `List` row selection and focus movement as one handled operation.
- Suppress only duplicate `List` fallback handling for synthetic-row events.
- Preserve ordinary bubbling from nested controls.
- Continue bubbling at collection boundaries.
- Skip untagged rows during selectable-list navigation.

All new dispatch types remain package-internal. The public `onKeyPress` API is unchanged.

## Testing

Added regression coverage for:

- Space reaching a consumer handler while a `List` row is focused.
- Selection and focus moving together during arrow navigation.
- Ancestor handlers not intercepting handled row navigation.
- Boundary arrows continuing to bubble.
- Scrolling keys reaching a `List` from nested controls.
- Navigation skipping untagged rows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/SwiftTUI/codesmith/swift-tui/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791721941&installation_model_id=427915&pr_number=17&repository=SwiftTUI%2Fswift-tui&return_to=https%3A%2F%2Fgithub.com%2FSwiftTUI%2Fswift-tui%2Fpull%2F17&signature=4cdabc37e3c9f631609aaf73c84b6b0cb9117ade50dc04bb8a6b0986a54ee57a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->